### PR TITLE
✨ (release-drafter.yml): Add release-drafter configuration file

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,45 @@
+name-template: "v$RESOLVED_VERSION 💙"
+tag-template: "v$RESOLVED_VERSION"
+autolabeler:
+  - label: "chore"
+    files:
+      - "*.md"
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: "bug"
+    branch:
+      - '/fix\/.+/'
+    title:
+      - "/fix/i"
+  - label: "enhancement"
+    branch:
+      - '/feature\/.+/'
+prerelease-identifier: "alpha"
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+  - title: "Bug Fixes"
+    labels:
+      - "patch"
+  - title: "Maintenance"
+    label: "chore"
+exclude-labels:
+  - "skip-changelog"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
This commit introduces a `.github/release-drafter.yml` configuration file to automate the creation of release drafts. The configuration specifies how to generate release names, tags, and changelogs based on commit messages and labels. This automation will streamline the release process and improve the consistency of release information.