### PR TITLE
♻️ (release-drafter.yml): rename enhancement label to feature and remove unused chore label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,8 +2,6 @@ name-template: v$RESOLVED_VERSION 💙
 tag-template: v$RESOLVED_VERSION
 autolabeler:
   - label: chore
-    files:
-      - '*.md'
     branch:
       - '/docs{0,1}\/.+/'
   - label: bug
@@ -11,7 +9,7 @@ autolabeler:
       - '/fix\/.+/'
     title:
       - /fix/i
-  - label: enhancement
+  - label: feature
     branch:
       - '/feature\/.+/'
 prerelease-identifier: alpha


### PR DESCRIPTION
The `enhancement` label was renamed to `feature` to better reflect its purpose and align with more common naming conventions. The unused `chore` label was removed to simplify the configuration and reduce clutter.