### PR TITLE
✨ (prose.css): Add text-wrap to prose links

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -3,6 +3,7 @@
 }
 .prose a {
   --at-apply: prose-link;
+  text-wrap: wrap;
 }
 .prose strong {
   font-weight: 600;


### PR DESCRIPTION
This change ensures that links within prose text wrap properly, preventing them from overflowing their container and breaking the layout.