### PR TITLE
🌐 (src/content/config.ts): Change locale to German for blog post dates

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -28,9 +28,9 @@ const blog = defineCollection({
       .string()
       .or(z.date())
       .transform((val: string | number | Date) =>
-        new Date(val).toLocaleDateString('en-US', {
+        new Date(val).toLocaleDateString('de-DE', {
           year: 'numeric',
-          month: 'short',
+          month: 'long',
           day: 'numeric',
         }),
       ),


### PR DESCRIPTION
The locale for blog post dates has been updated to German ('de-DE') to better support a German-speaking audience. The month format has also been changed to 'long' to display the full month name.